### PR TITLE
Removed requirement for model object input in looming_animation_calib

### DIFF
--- a/R/looming_animation_calib.R
+++ b/R/looming_animation_calib.R
@@ -3,29 +3,9 @@
 #'@description All screens are different, so an object of a hypothetical size
 #'  may be displayed at a different size on a different screen, due to
 #'  differences in resolution or the physical size of the pixels that make up
-#'  the screen.
+#'  the screen. \code{looming_animation_calib} is a utility to help calibrate
+#'  the \code{\link{looming_animation}} function for a particular screen.
 #'
-#'  \code{looming_animation_calib} is a utility to create a short animation from
-#'  an object of class \code{\link{constant_speed_model}},
-#'  \code{\link{variable_speed_model}}, or \code{\link{diameter_model}}. It
-#'  requires \code{ffmpeg} (\url{http://ffmpeg.org}), an external,
-#'  cross-platform, command line utility for encoding video, to be installed on
-#'  your system. The function allows the \code{correction} value (typically in
-#'  the range 0.01 - 0.06) used in \code{looming_animation} to be determined,
-#'  and checks the desired screen diameter is correctly displayed. Requires
-#'  access to the screen you intend to display the animation on, and a ruler or
-#'  other method of physically measuring lengths on the screen. Output is a
-#'  short 60 frame video containing a static image of 10 horizontal bars (it is
-#'  not an image file to ensure software rendering onscreen is consistent). This
-#'  video should be paused, made fullscreen and the bar closest in length to the
-#'  entered \code{ruler} value used to estimate the correct \code{correction}
-#'  value. The function can be run again to further refine estimates of the
-#'  \code{correction} value, if the \code{ruler} width falls between two
-#'  \code{correction} values. The \code{ruler} value should be less than the
-#'  physical horizontal width of the screen, or - obviously - it will be too
-#'  large to display. If creating different animations, the \code{correction}
-#'  value will be the same for a particular screen as long as the display
-#'  resolution remains the same (see Details).
 #'
 #'@details IMPORTANT: The function works by saving an image
 #'  (\code{loom_img_01.png} etc.) for every frame of the animation to the
@@ -35,17 +15,21 @@
 #'  any \code{.png} or \code{.mp4} file it encounters which has an identical
 #'  name.
 #'
-#'  The function creates a 60 frame video containing a static image of 10
-#'  horizontal bars along with the \code{correction} value used to create each.
-#'  It is a video and not an image file to ensure software rendering onscreen is
-#'  consistent. Open the file in the software you intend to use to play back the
-#'  final animation, make it fullscreen, pause it, and physically measure the
-#'  bars on the screen with a ruler to identify the correct \code{correction}
-#'  value. If the closest result to the \code{ruler} width falls between two
-#'  values, these can be entered as the \code{correction_range} and the function
-#'  re-run to further refine the estimate. When a good value is determined, this
-#'  should be used as the \code{correction} value in the
-#'  \code{looming_animation} function to produce the final animation.
+#'  The function helps determine the \code{correction} value used in
+#'  \code{\link{looming_animation}} to ensure screen diameters are correctly
+#'  displayed. Typically this is in the range 0.01 - 0.06, with the larger the
+#'  screen the lower the value. It requires access to the screen you intend to
+#'  display the animation on, and a ruler or other method of physically
+#'  measuring lengths on the screen. The output is a short 2 second, 60 frame
+#'  video containing a static image of 10 horizontal bars (it is not an image
+#'  file to ensure software rendering onscreen is consistent). This video should
+#'  be opened in the playback application, paused, made fullscreen and the bar
+#'  closest in length to the entered \code{ruler} value used to estimate an
+#'  appropriate \code{correction} value. If the \code{ruler} width falls between
+#'  two values, these can be entered as the \code{correction_range}, and the
+#'  function run again to further refine estimates of the \code{correction}
+#'  value. The \code{ruler} value should be less than the physical horizontal
+#'  width of the screen, or - obviously - the bars will be too wide to display.
 #'
 #'  The display resolution of the screen you will use to play the animation
 #'  should be entered as \code{width} and \code{height}. NOTE - This is the
@@ -53,12 +37,11 @@
 #'  of the screen, but determined in the Displays preferences of your operating
 #'  system. If you are unsure, visit \url{https://whatismyscreenresolution.com}
 #'  on the device. These settings ensure the animation is in the correct aspect
-#'  ratio and uses the full screen (although you are free to modify the aspect
-#'  ratio if, for example, you want your animation to be square). Incorrect
-#'  resolution values *should* still produce the correct widths onscreen,
-#'  however I cannot guarantee all playback software will honour this, so best
-#'  to follow the above guidelines if these details are important in your
-#'  experiment.
+#'  ratio and uses the full screen.
+#'
+#'  Note that if you are creating multiple animations, the \code{correction}
+#'  value used in \code{\link{looming_animation}} will be the same for a
+#'  particular screen as long as the display resolution remains the same.
 #'
 #'  The function should work with both Windows and macOS (Linux coming soon),
 #'  however it requires \code{ffmpeg} (\url{http://ffmpeg.org}), an external,
@@ -71,25 +54,22 @@
 #'
 #'
 #'
-#'
 #'  \subsection{Note on smaller screens}{If you are using the function to
 #'  calibrate for a small screen, for example a phone or tablet, the resulting
 #'  video might look strange: low resolution, blurry, bad spacing, etc. This is
-#'  a result of having to scale the text size to display properly. It should not
-#'  affect the estimation of the \code{calibration} value. Please do let me know
-#'  if you have any issues however.}
+#'  normal, and a result of having to scale the text size to display properly.
+#'  It should not affect the estimation of the \code{calibration} value, or the
+#'  animation you eventually create in \code{\link{looming_animation}}. Please
+#'  do let me know if you have any issues however.}
 #'
 #'@section Dependencies: The function requires the following packages:
 #'  \code{glue}.
 #'
-#'@seealso \code{\link{constant_speed_model}},
-#'  \code{\link{variable_speed_model}},  \code{\link{diameter_model}},
-#'  \code{\link{looming_animation}}
+#'@seealso \code{\link{looming_animation}}
 #'
-#'@param x A list object of class \code{constant_speed_model},
-#'  \code{variable_speed_model}, or \code{\link{diameter_model}}
 #'@param correction_range numeric vector of length = 2. Upper and lower range of
-#'  the correction factors to be tested
+#'  the correction factors to be tested. Defaults to \code{c(0.02, 0.03)}.
+#'  Larger screens require lower values.
 #'@param width integer. Width resolution of the display. E.g. for a display set
 #'  at 1080p resolution (1920x1080), this is \code{width = 1920}. Note: this is
 #'  NOT the native resolution, but the display resolution as set in the
@@ -105,15 +85,7 @@
 #'  will be too large to display.
 #'
 #' @examples
-#' # make a looming model
-#' loom_model <- constant_speed_model(
-#'                      screen_distance = 20,
-#'                      anim_frame_rate = 60,
-#'                      speed = 500,
-#'                      attacker_diameter = 50,
-#'                      start_distance = 1000)
-#'
-#' # use it to create a calibration video
+#' # Create a calibration video for checking a 10cm width
 #' looming_animation_calib(loom_model,
 #'                            correction_range = c(0.02, 0.03),
 #'                            width = 1920,
@@ -128,15 +100,10 @@
 
 looming_animation_calib <-
 
-  function(x,
-           correction_range = c(0.02, 0.03),
+  function(correction_range = c(0.02, 0.03),
            width = 1920,
            height = 1080,
            ruler = 10){
-
-    ## check class
-    if(!any(class(x) %in% c("constant_speed_model", "variable_speed_model", "diameter_model")))
-      stop("Input must be an object of class 'constant_speed_model', 'variable_speed_model', or 'diameter_model'")
 
     ## check for odd numbered screen resolutions, and if so add a pixel
     ## odd numbers cause "not divisible by 2" error in ffmpeg
@@ -147,8 +114,8 @@ looming_animation_calib <-
       height <- height +1
     }
 
-    ## extract data
-    frame_rate <- x$anim_frame_rate
+    ## set parameters
+    frame_rate <- 30
     total_frames <- 60
 
     ## vector of 10 correction values to try
@@ -158,6 +125,7 @@ looming_animation_calib <-
     ## make new 10cm lengths using different correction values
     ruler_lengths <- corr_values * ruler
 
+    ## set display positions
     x_left <- 0.05
 
     x_right <- c(0.05 + ruler_lengths[1],

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The package can create a simple animation of a desired duration with inputs for 
 
 Many other options are available, such as modifying the colour and background of the animation, padding the video to a desired total duration, marking frames to assist with identifying when escape responses occur, and more. 
 
-Note, `loomeR` currently only works in R on **macOS** and **Windows**, and requires [ffmpeg](http://ffmpeg.org), a free, cross-platform, command-line utility for encoding video to be installed on your system. **Linux** support is planned: please [get in touch](mailto:nicholascarey@gmail.com) if you would like to help with implementing that. 
+Note, `loomeR` currently only works in R on **macOS** and **Windows**, and requires [ffmpeg](http://ffmpeg.org), a free, cross-platform, command-line utility for encoding video to be installed on your system. **Linux** support is planned: please [get in touch](mailto:nicholascarey@gmail.com) if you can help with testing on Linux systems. 
 
 ### Installation
 `loomeR` is not yet published on CRAN, but can be installed using the `devtools` package:

--- a/man/looming_animation_calib.Rd
+++ b/man/looming_animation_calib.Rd
@@ -4,15 +4,13 @@
 \alias{looming_animation_calib}
 \title{Create a short animation for calibrating the looming animation function}
 \usage{
-looming_animation_calib(x, correction_range = c(0.02, 0.03), width = 1920,
+looming_animation_calib(correction_range = c(0.02, 0.03), width = 1920,
   height = 1080, ruler = 10)
 }
 \arguments{
-\item{x}{A list object of class \code{constant_speed_model},
-\code{variable_speed_model}, or \code{\link{diameter_model}}}
-
 \item{correction_range}{numeric vector of length = 2. Upper and lower range of
-the correction factors to be tested}
+the correction factors to be tested. Defaults to \code{c(0.02, 0.03)}.
+Larger screens require lower values.}
 
 \item{width}{integer. Width resolution of the display. E.g. for a display set
 at 1080p resolution (1920x1080), this is \code{width = 1920}. Note: this is
@@ -34,29 +32,9 @@ will be too large to display.}
 All screens are different, so an object of a hypothetical size
  may be displayed at a different size on a different screen, due to
  differences in resolution or the physical size of the pixels that make up
- the screen.
-
- \code{looming_animation_calib} is a utility to create a short animation from
- an object of class \code{\link{constant_speed_model}},
- \code{\link{variable_speed_model}}, or \code{\link{diameter_model}}. It
- requires \code{ffmpeg} (\url{http://ffmpeg.org}), an external,
- cross-platform, command line utility for encoding video, to be installed on
- your system. The function allows the \code{correction} value (typically in
- the range 0.01 - 0.06) used in \code{looming_animation} to be determined,
- and checks the desired screen diameter is correctly displayed. Requires
- access to the screen you intend to display the animation on, and a ruler or
- other method of physically measuring lengths on the screen. Output is a
- short 60 frame video containing a static image of 10 horizontal bars (it is
- not an image file to ensure software rendering onscreen is consistent). This
- video should be paused, made fullscreen and the bar closest in length to the
- entered \code{ruler} value used to estimate the correct \code{correction}
- value. The function can be run again to further refine estimates of the
- \code{correction} value, if the \code{ruler} width falls between two
- \code{correction} values. The \code{ruler} value should be less than the
- physical horizontal width of the screen, or - obviously - it will be too
- large to display. If creating different animations, the \code{correction}
- value will be the same for a particular screen as long as the display
- resolution remains the same (see Details).
+ the screen. \code{looming_animation_calib} is a utility to create a short
+ animation to calibrate the \code{\link{looming_animation}} function for a
+ particular screen.
 }
 \details{
 IMPORTANT: The function works by saving an image
@@ -67,17 +45,21 @@ IMPORTANT: The function works by saving an image
  any \code{.png} or \code{.mp4} file it encounters which has an identical
  name.
 
- The function creates a 60 frame video containing a static image of 10
- horizontal bars along with the \code{correction} value used to create each.
- It is a video and not an image file to ensure software rendering onscreen is
- consistent. Open the file in the software you intend to use to play back the
- final animation, make it fullscreen, pause it, and physically measure the
- bars on the screen with a ruler to identify the correct \code{correction}
- value. If the closest result to the \code{ruler} width falls between two
- values, these can be entered as the \code{correction_range} and the function
- re-run to further refine the estimate. When a good value is determined, this
- should be used as the \code{correction} value in the
- \code{looming_animation} function to produce the final animation.
+ The function helps determine the \code{correction} value used in
+ \code{\link{looming_animation}} to ensure screen diameters are correctly
+ displayed. Typically this is in the range 0.01 - 0.06, with the larger the
+ screen the lower the value. It requires access to the screen you intend to
+ display the animation on, and a ruler or other method of physically
+ measuring lengths on the screen. The output is a short 2 second, 60 frame
+ video containing a static image of 10 horizontal bars (it is not an image
+ file to ensure software rendering onscreen is consistent). This video should
+ be opened in the playback application, paused, made fullscreen and the bar
+ closest in length to the entered \code{ruler} value used to estimate an
+ appropriate \code{correction} value. If the \code{ruler} width falls between
+ two values, these can be entered as the \code{correction_range}, and the
+ function run again to further refine estimates of the \code{correction}
+ value. The \code{ruler} value should be less than the physical horizontal
+ width of the screen, or - obviously - the bars will be too wide to display.
 
  The display resolution of the screen you will use to play the animation
  should be entered as \code{width} and \code{height}. NOTE - This is the
@@ -85,12 +67,11 @@ IMPORTANT: The function works by saving an image
  of the screen, but determined in the Displays preferences of your operating
  system. If you are unsure, visit \url{https://whatismyscreenresolution.com}
  on the device. These settings ensure the animation is in the correct aspect
- ratio and uses the full screen (although you are free to modify the aspect
- ratio if, for example, you want your animation to be square). Incorrect
- resolution values *should* still produce the correct widths onscreen,
- however I cannot guarantee all playback software will honour this, so best
- to follow the above guidelines if these details are important in your
- experiment.
+ ratio and uses the full screen.
+
+ Note that if you are creating multiple animations, the \code{correction}
+ value used in \code{\link{looming_animation}} will be the same for a
+ particular screen as long as the display resolution remains the same.
 
  The function should work with both Windows and macOS (Linux coming soon),
  however it requires \code{ffmpeg} (\url{http://ffmpeg.org}), an external,
@@ -102,14 +83,13 @@ IMPORTANT: The function works by saving an image
 
 
 
-
-
  \subsection{Note on smaller screens}{If you are using the function to
  calibrate for a small screen, for example a phone or tablet, the resulting
  video might look strange: low resolution, blurry, bad spacing, etc. This is
- a result of having to scale the text size to display properly. It should not
- affect the estimation of the \code{calibration} value. Please do let me know
- if you have any issues however.}
+ normal, and a result of having to scale the text size to display properly.
+ It should not affect the estimation of the \code{calibration} value, or the
+ animation you eventually create in \code{\link{looming_animation}}. Please
+ do let me know if you have any issues however.}
 }
 \section{Dependencies}{
  The function requires the following packages:
@@ -117,15 +97,7 @@ IMPORTANT: The function works by saving an image
 }
 
 \examples{
-# make a looming model
-loom_model <- constant_speed_model(
-                     screen_distance = 20,
-                     anim_frame_rate = 60,
-                     speed = 500,
-                     attacker_diameter = 50,
-                     start_distance = 1000)
-
-# use it to create a calibration video
+# Create a calibration video for checking a 10cm width
 looming_animation_calib(loom_model,
                            correction_range = c(0.02, 0.03),
                            width = 1920,
@@ -134,9 +106,7 @@ looming_animation_calib(loom_model,
 
 }
 \seealso{
-\code{\link{constant_speed_model}},
- \code{\link{variable_speed_model}},  \code{\link{diameter_model}},
- \code{\link{looming_animation}}
+\code{\link{looming_animation}}
 }
 \author{
 Nicholas Carey - \email{nicholascarey@gmail.com}


### PR DESCRIPTION
Removed requirement for model object input in looming_animation_calib. Originally this fn required a model be created. This was not actually necessary for the fn to do its job, and was only used to get a frame rate. Instead made frame rate of 30 the default. 