### PR TITLE
Much better file naming code in looming_animation and looming_animati…

### DIFF
--- a/R/looming_animation.R
+++ b/R/looming_animation.R
@@ -418,12 +418,9 @@ looming_animation <-
 
     ## create image for each frame
     for(i in 1:total_frames){
-      # create a name for each file with leading zeros
-      if (i < 10) {name = paste('loom_img_', '00000',i,'.png',sep='')}
-      if (i < 100 && i >= 10) {name = paste('loom_img_', '0000',i,'.png', sep='')}
-      if (i < 1000 && i >= 100) {name = paste('loom_img_', '000', i,'.png', sep='')}
-      if (i < 10000 && i >= 1000) {name = paste('loom_img_', '00', i,'.png', sep='')}
-      if (i >= 10000) {name = paste('loom_img_', '0', i,'.png', sep='')}
+
+      # create filename with leading zeros up to 6 numerals total
+      name <- paste0("loom_img_", sprintf("%06d", i), ".png")
 
       # make png file
       png(name, width=width, height=height, res=72)

--- a/R/looming_animation_calib.R
+++ b/R/looming_animation_calib.R
@@ -151,9 +151,9 @@ looming_animation_calib <-
 
     ## create image for each frame
     for(i in 1:total_frames){
-      # create a name for each file with leading zeros
-      if (i < 10) {name = paste('loom_img_', '0',i,'.png',sep='')}
-      if (i < 100 && i >= 10) {name = paste('loom_img_',i,'.png', sep='')}
+
+      # create filename with leading zeros up to 2 numerals total
+      name <- paste0("loom_img_", sprintf("%02d", i), ".png")
 
       # make png file
         # res= here is a bit of a hack to scale the text so that it's readable on

--- a/loomeR.Rproj
+++ b/loomeR.Rproj
@@ -18,4 +18,5 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageCheckArgs: --as-cran
 PackageRoxygenize: rd,collate,namespace

--- a/tests/testthat/test-looming_animation.R
+++ b/tests/testthat/test-looming_animation.R
@@ -119,19 +119,6 @@ expect_message(looming_animation(x,
                 "Screen `height` cannot be an odd number.")
 
 
-# test --------------------------------------------------------------------
-
-## test huge padding
-skip_on_cran()
-x <- loomeR::diameter_model(start_diameter = 10,
-                            end_diameter = 9.5,
-                            duration = 90,
-                            frame_rate = 120)
-
-expect_error(looming_animation(x),
-               NA)
-
-
 # Skip on travis tests ----------------------------------------------------
 
 # test --------------------------------------------------------------------


### PR DESCRIPTION
Much better file naming code in looming_animation and looming_animation_calib. Using regex. Also allows removal of the test with huge padding. 